### PR TITLE
Auto JSON Mapping and More

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.vs
-.user
-.msi
+*.vs
+*.user
+*.msi
+*.zip
 **/bin/**
 **/obj/**

--- a/Src/App/Klipboard/Program.cs
+++ b/Src/App/Klipboard/Program.cs
@@ -12,21 +12,29 @@ namespace Klipboard
         [STAThread]
         static void Main()
         {
-            // To customize application configuration such as set high DPI settings or default font,
-            // see https://aka.ms/applicationconfiguration.
-            ApplicationConfiguration.Initialize();
+            if (!OpSysHelper.TryAcquireSingleProcessLock(out var processLock)) 
+            {
+                return;
+            }
 
-            var settings = Settings.Init().ConfigureAwait(false).GetAwaiter().GetResult();
-            var clipboardHelper = new ClipboardHelper();
+            using (processLock)
+            {
+                // To customize application configuration such as set high DPI settings or default font,
+                // see https://aka.ms/applicationconfiguration.
+                ApplicationConfiguration.Initialize();
 
-            var workers = CreateWorkers(settings);
-            using var notificationIcon = new NotificationIcon(workers, clipboardHelper);
+                var settings = Settings.Init().ConfigureAwait(false).GetAwaiter().GetResult();
+                var clipboardHelper = new ClipboardHelper();
 
-            VersionHelper.StartPolling();
+                var workers = CreateWorkers(settings);
+                using var notificationIcon = new NotificationIcon(workers, clipboardHelper);
 
-            Application.Run();
+                VersionHelper.StartPolling();
 
-            VersionHelper.StopPolling();
+                Application.Run();
+
+                VersionHelper.StopPolling();
+            }
         }
 
         private static List<WorkerUxConfig> CreateWorkers(ISettings settings)

--- a/Src/App/Klipboard/Properties/PublishProfiles/SetupProfile.pubxml
+++ b/Src/App/Klipboard/Properties/PublishProfiles/SetupProfile.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Publish\KlipboradSetup</PublishDir>
+    <PublishDir>bin\Publish\KlipboardSetup</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
     <TargetFramework>net6.0-windows</TargetFramework>

--- a/Src/App/Utils/Helpers/OpSysHelper.cs
+++ b/Src/App/Utils/Helpers/OpSysHelper.cs
@@ -3,6 +3,22 @@
 
 namespace Klipboard.Utils
 {
+    public class AutoDispose : IDisposable
+    {
+        Action m_disposeAction;
+        
+        public AutoDispose(Action disposeAction)
+        {
+            m_disposeAction = disposeAction;
+        }
+
+        public void Dispose() 
+        {
+            m_disposeAction?.Invoke();
+            m_disposeAction = null;
+        }
+    }
+
     public static class OpSysHelper
     {
         public static void InvokeLink(string link)
@@ -14,6 +30,26 @@ namespace Klipboard.Utils
             });
 
             return;
+        }
+
+        public static bool TryAcquireSingleProcessLock(out AutoDispose? processLock)
+        {
+#if DEBUG
+            var name = $"{AppConstants.ApplicationName}_DEBUG";
+#else
+            var name = $"{AppConstants.ApplicationName}_RELEASE";
+#endif
+            var singleProcessMutex = new Mutex(initiallyOwned: false, name);
+
+            if (!singleProcessMutex.WaitOne(0))
+            {
+                singleProcessMutex.Dispose();
+                processLock = null;
+                return false;
+            }
+
+            processLock = new AutoDispose(() => singleProcessMutex.ReleaseMutex());
+            return true;
         }
     }
 }

--- a/Src/App/Utils/Helpers/OpSysHelper.cs
+++ b/Src/App/Utils/Helpers/OpSysHelper.cs
@@ -5,7 +5,7 @@ namespace Klipboard.Utils
 {
     public class AutoDispose : IDisposable
     {
-        Action m_disposeAction;
+        Action? m_disposeAction;
         
         public AutoDispose(Action disposeAction)
         {

--- a/Src/App/Utils/Helpers/TabularDataHelper.cs
+++ b/Src/App/Utils/Helpers/TabularDataHelper.cs
@@ -134,7 +134,7 @@ namespace Klipboard.Utils
             for (int i = 0; i < Columns.Count; i++)
             {
                 var col = Columns[i];
-                var colMapping = new ColumnMapping(NormalizeColumnName(col.Name, i), 
+                var colMapping = new ColumnMapping(StrippedColumnName(NormalizeColumnName(col.Name, i)), 
                     col.Type.Name, 
                     new Dictionary<string, string>() { {"Path", $"$.{StrippedColumnName(col.Name)}"} });
 

--- a/Src/App/Utils/Klipboard.Utils.csproj
+++ b/Src/App/Utils/Klipboard.Utils.csproj
@@ -11,7 +11,4 @@
     <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.3" />
     <PackageReference Include="Microsoft.Azure.Kusto.Ingest" Version="11.3.3" />
   </ItemGroup>
-
-
-
 </Project>

--- a/Src/App/Workers/Ingest/TempTableWorker.cs
+++ b/Src/App/Workers/Ingest/TempTableWorker.cs
@@ -208,9 +208,12 @@ namespace Klipboard.Workers
                 TableName = tempTableName,
                 Format = formatDefinition.Format,
                 IgnoreFirstRecord = firstRowIsHeader,
-                // TODO: Mapping does not fully work
-                // IngestionMapping = mapping,
             };
+
+            if (mapping != null)
+            {
+                ingestionProperties.IngestionMapping = mapping;
+            }
 
             var uploadBlobRes = await databaseHelper.TryDirectIngestStorageToTable(uploadRes.BlobUri, ingestionProperties, storageOptions);
 

--- a/Src/App/Workers/Ingest/TempTableWorker.cs
+++ b/Src/App/Workers/Ingest/TempTableWorker.cs
@@ -149,7 +149,7 @@ namespace Klipboard.Workers
                 var autoDetectRes = await databaseHelper.TryAutoDetectTextBlobScheme(uploadRes.BlobUri, firstRowIsHeader);
                 if (autoDetectRes.Success)
                 {
-                    schemaStr = autoDetectRes.Schema.ToString();
+                    schemaStr = autoDetectRes.Schema.ToSchemaString(strictEntityNaming: true);
                     formatDefinition = FileHelper.GetFormatFromExtension(autoDetectRes.Format);
                 }
                 else
@@ -162,7 +162,7 @@ namespace Klipboard.Workers
                 var schemaRes = await databaseHelper.TryGetBlobSchemeAsync(uploadRes.BlobUri, formatDefinition.Extension, firstRowIsHeader);
                 if (schemaRes.Success)
                 {
-                    schemaStr = schemaRes.TableScheme.ToString();
+                    schemaStr = schemaRes.TableScheme.ToSchemaString(strictEntityNaming: true);
                 }
                 else
                 {

--- a/Src/App/Workers/Klipboard.Workers.csproj
+++ b/Src/App/Workers/Klipboard.Workers.csproj
@@ -14,6 +14,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Utils\Klipboard.Utils.csproj" />
   </ItemGroup>
-
-
 </Project>

--- a/Src/App/Workers/Query/ExternalDataQueryWorker.cs
+++ b/Src/App/Workers/Query/ExternalDataQueryWorker.cs
@@ -90,7 +90,7 @@ namespace Klipboard.Workers
 
                     if (autoDetectRes.Success)
                     {
-                        schemaStr = autoDetectRes.Schema.ToString();
+                        schemaStr = autoDetectRes.Schema.ToSchemaString();
                         format = autoDetectRes.Format;
                         break;
                     }
@@ -113,7 +113,7 @@ namespace Klipboard.Workers
                     var schemaRes = await databaseHelper.TryGetBlobSchemeAsync(uploadRes.BlobUri, format: format, firstrowIsHeader);
                     if (schemaRes.Success)
                     {
-                        schemaStr = schemaRes.TableScheme.ToString();
+                        schemaStr = schemaRes.TableScheme.ToSchemaString();
                         break;
                     }
 

--- a/Src/BUILD_AND_PACK.md
+++ b/Src/BUILD_AND_PACK.md
@@ -17,13 +17,20 @@
 	1. Confirm the dialog requesting _ProductCode_ change
 
 ## Build
-1. Run `publish.bat`
+1. Run `build.bat` and confirm it ended sucessfully
 1. In Visual Studio, build the _Setup_ project
 
+## Pack
+1. Run `pack.bat` and confirm it ended sucessfully
+1. Make sure the following 2 zip files were created
+	1. `Src\App\bin\Publish\Klipboard.zip`
+	1. `Src\Setup\Release\KlipboardSetup.zip`
+
 ## Create a New Release
+1. Complete the version PR
 1. Go to release and create a new release.
 1. Set the release name to _v[Major].[Minor].\[Build\]_
 1. Set the release to create a tag with the value of _v[Major].[Minor].\[Build\]_
 1. Set the release notes including major changes included in the version
 1. Upload `Src\App\bin\Publish\Klipboard.zip`
-1. Upload `Src\Setup\Release\KlipboardSetup.msi`
+1. Upload `Src\Setup\Release\KlipboardSetup.zip`

--- a/Src/BUILD_AND_PACK.md
+++ b/Src/BUILD_AND_PACK.md
@@ -17,10 +17,13 @@
 	1. Confirm the dialog requesting _ProductCode_ change
 
 ## Build
-1. Run `build.bat` and confirm it ended sucessfully
+1. Open a shell (cmd) window and CD into the Src directory
+1. Run the build script `build.bat [version]` where _[version]_ is _v[Major].[Minor].\[Build\]_
+1. Confirm the build had ended sucessfully
 1. In Visual Studio, build the _Setup_ project
 
 ## Pack
+1. Open a shell (cmd) window and CD into the Src directory
 1. Run `pack.bat` and confirm it ended sucessfully
 1. Make sure the following 2 zip files were created
 	1. `Src\App\bin\Publish\Klipboard.zip`

--- a/Src/build.bat
+++ b/Src/build.bat
@@ -18,12 +18,6 @@ if %errorlevel% neq 0 ( goto BuildFailed)
 dotnet publish -p:configuration=Release /p:PublishProfile=SingleFile -p:PublishDir="bin\Publish\Klipboard"
 if %errorlevel% neq 0 ( goto BuildFailed)
 
-REM * Zip results
-cd App\Klipboard\bin\Publish\
-tar -acf Klipboard.zip Klipboard
-if %errorlevel% neq 0 ( goto BuildFailed)
-cd ..\..\..\..
-
 REM * Announce Success
 echo ****************
 echo Build Succeeded!

--- a/Src/build.bat
+++ b/Src/build.bat
@@ -1,4 +1,16 @@
+REM * Build the project before publishing it 
+REM * Usage:
+REM *   build.bat [version]
+
 echo off
+
+REM * Version 
+Set VERSION=%1
+if defined VERSION (goto Continue)
+echo Please pass the build version in the first argument e.g. > build.bat 1.0.0 
+goto End
+
+:Continue
 
 REM * Clean
 rmdir App\Klipboard\bin\Release /s /q
@@ -12,10 +24,10 @@ dotnet build -p:configuration=Release
 if %errorlevel% neq 0 ( goto BuildFailed)
 
 REM * Publish
-dotnet publish -p:configuration=Release /p:PublishProfile=SetupProfile -p:PublishDir="bin\Publish\KlipboardSetup"
+dotnet publish -p:Version=%VERSION% -p:configuration=Release /p:PublishProfile=SetupProfile -p:PublishDir="bin\Publish\KlipboardSetup"
 if %errorlevel% neq 0 ( goto BuildFailed)
 
-dotnet publish -p:configuration=Release /p:PublishProfile=SingleFile -p:PublishDir="bin\Publish\Klipboard"
+dotnet publish -p:Version=%VERSION% -p:configuration=Release /p:PublishProfile=SingleFile -p:PublishDir="bin\Publish\Klipboard"
 if %errorlevel% neq 0 ( goto BuildFailed)
 
 REM * Announce Success

--- a/Src/pack.bat
+++ b/Src/pack.bat
@@ -1,0 +1,29 @@
+echo off
+
+REM * Zip results
+cd App\Klipboard\bin\Publish\
+tar -acf Klipboard.zip Klipboard
+if %errorlevel% neq 0 ( goto PackFailed)
+cd ..\..\..\..
+
+REM * Zip results
+cd Setup\
+rename Release KlipboardSetup
+tar -acf KlipboardSetup.zip KlipboardSetup
+if %errorlevel% neq 0 ( goto PackFailed)
+cd ..
+
+REM * Announce Success
+echo ****************
+echo Pack Succeeded!
+echo ****************
+goto End
+
+REM * Announce Failure
+:PackFailed
+echo *************
+echo Pack Failed!
+echo *************
+
+REM * Go back to Src dir
+:End


### PR DESCRIPTION
* Less strict column name auto correct for datatable and external table
* When creating a temp table from json data and auto correcting column names, create a mapping policy to fix map between the json file and the column names
* Single process lock - service will not run twice (debug and release versions can run side by side)
* Improve publishing instructions and scripts
* Versioned published assemblies 