### PR TITLE
Local Kusto Support

### DIFF
--- a/Src/App/Utils/Common/AppConfig.cs
+++ b/Src/App/Utils/Common/AppConfig.cs
@@ -58,7 +58,11 @@ namespace Klipboard.Utils
         public AppConfigFile()
         {
             ConfigDir = OpSysHelper.AppFolderPath();
+#if DEBUG
+            ConfigPath = Path.Combine(ConfigDir, "config_debug.json");
+#else
             ConfigPath = Path.Combine(ConfigDir, "config.json");
+#endif
         }
 
         public AppConfigFile(string path)
@@ -136,5 +140,5 @@ namespace Klipboard.Utils
             }
         }
     }
-    #endregion
+#endregion
 }

--- a/Src/App/Utils/Common/AppConfig.cs
+++ b/Src/App/Utils/Common/AppConfig.cs
@@ -7,7 +7,8 @@ namespace Klipboard.Utils
     public enum QueryApp
     {
         Web,
-        Desktop
+        Desktop,
+        DesktopModern
     }
 
     public record Cluster(string ConnectionString, string DatabaseName);

--- a/Src/App/Utils/Common/AppConfig.cs
+++ b/Src/App/Utils/Common/AppConfig.cs
@@ -8,7 +8,6 @@ namespace Klipboard.Utils
     {
         Web,
         Desktop,
-        DesktopModern
     }
 
     public record Cluster(string ConnectionString, string DatabaseName);

--- a/Src/App/Utils/Helpers/FileHelper.cs
+++ b/Src/App/Utils/Helpers/FileHelper.cs
@@ -54,7 +54,7 @@ namespace Klipboard.Utils
         #region File Utils
         public static void CreateTempFile(string fileName, Stream dataStream, out string filePath)
         {
-            filePath = Path.Combine(Path.GetTempPath(), fileName);
+            filePath = FileHelper.NormalizeFilePathString(Path.Combine(Path.GetTempPath(), fileName));
             
             using var fileStream = new FileStream(filePath, FileMode.CreateNew);
 

--- a/Src/App/Utils/Helpers/FileHelper.cs
+++ b/Src/App/Utils/Helpers/FileHelper.cs
@@ -339,7 +339,7 @@ namespace Klipboard.Utils
             return UnknownFormatDefinition;
         }
 
-        public static IEnumerable<string> ExpandDropFileList(List<string> dropFiles, string? extension = null)
+        public static IEnumerable<string> ExpandDropFileList(IEnumerable<string> dropFiles, string? extension = null)
         {
             var wildCardFileMatcher = "*";
             var enumOptions = new EnumerationOptions()
@@ -362,7 +362,6 @@ namespace Klipboard.Utils
 
                 if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
                 {
-                    // TODO: this does not recursively explore directories
                     foreach (var subFile in Directory.GetFiles(path, wildCardFileMatcher, enumOptions))
                     {
                         yield return NormalizeFilePathString(subFile);

--- a/Src/App/Utils/Helpers/FileHelper.cs
+++ b/Src/App/Utils/Helpers/FileHelper.cs
@@ -9,6 +9,7 @@ namespace Klipboard.Utils
 
     public static class FileHelper
     {
+        #region Defintion and Constructor
         public static readonly FileFormatDefiniton UnknownFormatDefinition = new FileFormatDefiniton(DataSourceFormat.txt, AppConstants.UnknownFormat, DoNotCompress: false);
         public static readonly FileFormatDefiniton TsvFormatDefinition = new FileFormatDefiniton(DataSourceFormat.tsv, "tsv", DoNotCompress: false);
 
@@ -48,6 +49,21 @@ namespace Klipboard.Utils
             s_fileFormatDefinition.Add("txt", new FileFormatDefiniton(DataSourceFormat.txt, "txt", DoNotCompress: false));
             s_fileFormatDefinition.Add("log", new FileFormatDefiniton(DataSourceFormat.txt, "txt", DoNotCompress: false));
         }
+        #endregion
+
+        #region File Utils
+        public static void CreateTempFile(string fileName, Stream dataStream, out string filePath)
+        {
+            filePath = Path.Combine(Path.GetTempPath(), fileName);
+            
+            using var fileStream = new FileStream(filePath, FileMode.CreateNew);
+
+            dataStream.Seek(0, SeekOrigin.Begin);
+            dataStream.CopyTo(fileStream);
+            fileStream.Flush();
+            fileStream.Close();
+        }
+        #endregion
 
         #region Path Utils
         /// <summary>

--- a/Src/App/Utils/Helpers/FileHelper.cs
+++ b/Src/App/Utils/Helpers/FileHelper.cs
@@ -362,9 +362,10 @@ namespace Klipboard.Utils
 
                 if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
                 {
+                    // TODO: this does not recursively explore directories
                     foreach (var subFile in Directory.GetFiles(path, wildCardFileMatcher, enumOptions))
                     {
-                        yield return subFile;
+                        yield return NormalizeFilePathString(subFile);
                     }
                 }
 
@@ -378,10 +379,25 @@ namespace Klipboard.Utils
                     continue;
                 }
 
-                yield return path;
+                yield return NormalizeFilePathString(path);
             }
 
             yield break;
+        }
+
+        /// <summary>
+        /// Replaces all backslashes with forward slashes, so the file path requires no escaping when represented as a string in KQL
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns>normalized file path</returns>
+        public static string NormalizeFilePathString(string path)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                path = path.Replace(@"\", "/"); ;
+            }
+
+            return path;
         }
         #endregion
 

--- a/Src/App/Utils/Helpers/InlineQueryHelper.cs
+++ b/Src/App/Utils/Helpers/InlineQueryHelper.cs
@@ -13,7 +13,13 @@ namespace Klipboard.Utils
 
         public static bool TryInvokeInlineQuery(AppConfig appConfig, string clusterUri, string databaseName, string query, out string? error)
         {
-            var clusterHost = clusterUri.Trim().TrimEnd('/').Replace("https://", "");
+            var clusterHost = clusterUri;
+            
+            if (Uri.TryCreate(clusterUri, UriKind.Absolute, out var uri))
+            {
+                clusterHost = uri.Host;
+            }
+            
             string queryLink;
 
             if (string.IsNullOrWhiteSpace(query))

--- a/Src/App/Utils/Helpers/InlineQueryHelper.cs
+++ b/Src/App/Utils/Helpers/InlineQueryHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Kusto.Data;
+﻿using Kusto.Data;
 
 
 namespace Klipboard.Utils
@@ -38,11 +37,12 @@ namespace Klipboard.Utils
 
             if (appConfig.DefaultQueryApp == QueryApp.Desktop)
             {
-                queryLink = new Uri(uri, $"{databaseName}?query={query}&web=0").ToString(); ;
+                string uriParam = $"Data Source={clusterUri};Initial Catalog={databaseName}";
+                queryLink = new Uri(uri, $"?uri={uriParam}&query={query}&web=0").ToString();
             }
             else
             {
-                queryLink = $"https://dataexplorer.azure.com/clusters/{uri.Host}/databases/{databaseName}?query={query}";
+                queryLink = new Uri(new Uri("https://dataexplorer.azure.com/"), $"/clusters/{uri.Host}/databases/{databaseName}?&query={query}").ToString();
             }
 
             OpSysHelper.InvokeLink(queryLink);

--- a/Src/App/Utils/Helpers/InlineQueryHelper.cs
+++ b/Src/App/Utils/Helpers/InlineQueryHelper.cs
@@ -13,11 +13,10 @@ namespace Klipboard.Utils
 
         public static bool TryInvokeInlineQuery(AppConfig appConfig, string clusterUri, string databaseName, string query, out string? error)
         {
-            var clusterHost = clusterUri;
-            
-            if (Uri.TryCreate(clusterUri, UriKind.Absolute, out var uri))
+            if (!Uri.TryCreate(clusterUri, UriKind.Absolute, out var uri))
             {
-                clusterHost = uri.Host;
+                error = "ClusterUri is not a valid Uri.";
+                return false;
             }
             
             string queryLink;
@@ -39,11 +38,11 @@ namespace Klipboard.Utils
 
             if (appConfig.DefaultQueryApp == QueryApp.Desktop)
             {
-                queryLink = $"https://{clusterHost}/{databaseName}?query={query}&web=0";
+                queryLink = new Uri(uri, $"{databaseName}?query={query}&web=0").ToString(); ;
             }
             else
             {
-                queryLink = $"https://dataexplorer.azure.com/clusters/{clusterHost}/databases/{databaseName}?query={query}";
+                queryLink = $"https://dataexplorer.azure.com/clusters/{uri.Host}/databases/{databaseName}?query={query}";
             }
 
             OpSysHelper.InvokeLink(queryLink);

--- a/Src/App/Utils/Helpers/InlineQueryHelper.cs
+++ b/Src/App/Utils/Helpers/InlineQueryHelper.cs
@@ -28,6 +28,7 @@ namespace Klipboard.Utils
             }
 
             error = null;
+            query = TabularDataHelper.GzipBase64(query);
 
             if (AppConstants.EnforceInlineQuerySizeLimits && query.Length > AppConstants.MaxAllowedQueryLength)
             {
@@ -38,28 +39,14 @@ namespace Klipboard.Utils
             switch (appConfig.DefaultQueryApp)
             {
                 case QueryApp.Desktop:
-                    query = TabularDataHelper.GzipBase64(query);
-                    uriParam = $"Data Source={clusterUri};Initial Catalog={databaseName}";
-                    queryLink = new Uri(uri, $"?uri={uriParam}&query={query}&web=0").ToString();
-                    break;
-                
-                case QueryApp.DesktopModern:
                     uriParam = $"Data Source={clusterUri};Initial Catalog={databaseName}";
                     queryLink = $"kusto://query?uri={Uri.EscapeDataString(uriParam)}&query={Uri.EscapeDataString(query)}";
                     break;
 
                 case QueryApp.Web:
                 default: // compilation fix
-                    query = TabularDataHelper.GzipBase64(query);
-                    queryLink = new Uri(new Uri("https://dataexplorer.azure.com/"), $"/clusters/{uri.Host}/databases/{databaseName}?&query={query}").ToString();
+                    queryLink = $"https://dataexplorer.azure.com/clusters/{Uri.EscapeDataString(uri.Host)}/databases/{Uri.EscapeDataString(databaseName)}?&query={Uri.EscapeDataString(query)}";
                     break;
-            }
-
-            if (queryLink.Length > AppConstants.MaxAllowedQueryLength)
-            {
-                // TODO: If an when Clipboard Query Target is supported, place the query back to the klipboard
-                error = $"Resulting query link excceds {AppConstants.MaxAllowedQueryLengthKB}KB.";
-                return false;
             }
 
             OpSysHelper.InvokeLink(queryLink);

--- a/Src/App/Utils/Helpers/KustoDatabaseHelper.cs
+++ b/Src/App/Utils/Helpers/KustoDatabaseHelper.cs
@@ -91,6 +91,7 @@ namespace Klipboard.Utils
 
         public async Task<(bool Success, TableColumns? TableScheme, string? format, string? Error)> TryGetBlobSchemeAsync(string blobUri, string? format = null, bool? firstRowIsHeader = null)
         {
+            blobUri = blobUri.Replace(@"\", "/");
             var formatStr = (format != null) ? $", '{format}'" : string.Empty;
             var firstRowStr = (format != null && firstRowIsHeader != null) ? $", dynamic({{'UseFirstRowAsHeader':{firstRowIsHeader}}})" : string.Empty;
             var cmd = $"evaluate external_data_schema('{blobUri}'{formatStr}{firstRowStr})";

--- a/Src/App/Utils/Helpers/KustoDatabaseHelper.cs
+++ b/Src/App/Utils/Helpers/KustoDatabaseHelper.cs
@@ -91,7 +91,6 @@ namespace Klipboard.Utils
 
         public async Task<(bool Success, TableColumns? TableScheme, string? format, string? Error)> TryGetBlobSchemeAsync(string blobUri, string? format = null, bool? firstRowIsHeader = null)
         {
-            blobUri = blobUri.Replace(@"\", "/");
             var formatStr = (format != null) ? $", '{format}'" : string.Empty;
             var firstRowStr = (format != null && firstRowIsHeader != null) ? $", dynamic({{'UseFirstRowAsHeader':{firstRowIsHeader}}})" : string.Empty;
             var cmd = $"evaluate external_data_schema('{blobUri}'{formatStr}{firstRowStr})";

--- a/Src/App/Utils/Helpers/KustoDatabaseHelper.cs
+++ b/Src/App/Utils/Helpers/KustoDatabaseHelper.cs
@@ -11,10 +11,15 @@ namespace Klipboard.Utils
     public class KustoDatabaseHelper : IDisposable
     {
         #region Members
+        private static readonly HashSet<string> s_localhosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "localhost", "127.0.0.1", "::1", "[::1]" };
+        
         private Lazy<ICslAdminProvider> m_engineAdminClient;
         private Lazy<ICslQueryProvider> m_engineQueryClient;
         private Lazy<IKustoIngestClient> m_directIngestClient;
-        private string m_databaseName = string.Empty;
+        
+        private readonly string m_databaseName = string.Empty;
+        private readonly bool m_localhost = false;
+        private readonly bool m_userHttps = false;
         #endregion
 
         #region Construction
@@ -30,8 +35,14 @@ namespace Klipboard.Utils
 
         public KustoDatabaseHelper(KustoConnectionStringBuilder connectionString, string databaseName)
         {
+            m_localhost = s_localhosts.Contains(connectionString.Hostname);
+            m_userHttps = connectionString.ConnectionScheme == "https";
+
             // TODO: This needs to be UX driven
-            var engineKcsb = new KustoConnectionStringBuilder(connectionString).WithAadUserPromptAuthentication();
+            var engineKcsb = m_userHttps ?
+                new KustoConnectionStringBuilder(connectionString).WithAadUserPromptAuthentication() :
+                new KustoConnectionStringBuilder(connectionString.DataSource);
+
             engineKcsb.SetConnectorDetails(AppConstants.ApplicationName, AppConstants.ApplicationVersion.ToString(), sendUser: false);
 
             m_engineAdminClient = new Lazy<ICslAdminProvider>(() => KustoClientFactory.CreateCslAdminProvider(engineKcsb));
@@ -50,8 +61,18 @@ namespace Klipboard.Utils
         #endregion
 
         #region Public APIs
-        public async Task<(bool Success, string? BlobUri, string? Error)> TryUploadFileToEngineStagingAreaAsync(Stream dataStream, string upstreamFileName, FileFormatDefiniton formatDefintion)
+        public async Task<(bool Success, string? BlobUri, string? Error)> TryUploadFileToEngineStagingAreaAsync(Stream dataStream, string upstreamFileName, FileFormatDefiniton formatDefintion, string? filePath = null)
         {
+            if (m_localhost)
+            {
+                if (filePath == null)
+                {
+                    FileHelper.CreateTempFile(upstreamFileName, dataStream, out filePath);
+                }
+
+                return (Success: true, BlobUri: filePath, Error: null);
+            }
+
             try
             {
                 using var res = await m_engineAdminClient.Value.ExecuteControlCommandAsync(m_databaseName, ".create tempstorage");
@@ -182,6 +203,27 @@ namespace Klipboard.Utils
         {
             try
             {
+                if (m_localhost)
+                {
+                    sourceOptions.IsLocalFileSystem = true;
+                    sourceOptions.Compress = false;
+                    var command =
+                        CslCommandGenerator.GenerateTableIngestPullCommand(
+                            ingestionProperties.TableName,
+                            new[] { blobUriOrFile },
+                            isAsync: false,
+                            extensions: ingestionProperties.GetIngestionProperties());
+
+                    using var resultReader = await m_engineAdminClient.Value.ExecuteControlCommandAsync(m_databaseName, command).ConfigureAwait(false);
+                    
+                    resultReader.Read();
+                    
+                    var hasErrors = resultReader.GetBoolean(3);
+                    var error = hasErrors? $"Ingest oprtation '{resultReader.GetString(4)}' failed" : null;
+
+                    return (Success: !hasErrors, Error: error);
+                }
+
                 var res = await m_directIngestClient.Value.IngestFromStorageAsync(blobUriOrFile, ingestionProperties, sourceOptions);
                 var ingestStatus = res.GetIngestionStatusBySourceId(sourceOptions.SourceId);
 

--- a/Src/App/Workers/Ingest/TempTableWorker.cs
+++ b/Src/App/Workers/Ingest/TempTableWorker.cs
@@ -95,7 +95,8 @@ namespace Klipboard.Workers
                 {
                     using var file = File.OpenRead(path);
 
-                    var success = await HandleSingleTextStreamAsync(databaseHelper, tempTableName, file, formatResult, upstreamFileName, chosenOption, progressNotification);
+                    var success = await HandleSingleTextStreamAsync(databaseHelper, tempTableName, file, formatResult, upstreamFileName, chosenOption, progressNotification, path
+                        );
                     if (!success)
                     {
                         // A notification was sent from the failed function
@@ -151,13 +152,14 @@ namespace Klipboard.Workers
             FileFormatDefiniton formatDefinition, 
             string upstreamFileName, 
             string? chosenOption,
-            IProgressNotificationUpdater progressNotification)
+            IProgressNotificationUpdater progressNotification,
+            string? filePath = null)
         {
             const double steps = 5 * 2; // double 2 => (step / steps) * (50 / 100) = step / (steps * 2)
 
             // Steps #1
             progressNotification.UpdateProgress("Uploading initial data", 1 / steps, "");
-            var uploadRes = await databaseHelper.TryUploadFileToEngineStagingAreaAsync(dataStream, upstreamFileName, formatDefinition);
+            var uploadRes = await databaseHelper.TryUploadFileToEngineStagingAreaAsync(dataStream, upstreamFileName, formatDefinition, filePath);
             var firstRowIsHeader = FirstRowIsHeader.Equals(chosenOption);
 
             if (!uploadRes.Success)

--- a/Src/App/Workers/Ingest/TempTableWorker.cs
+++ b/Src/App/Workers/Ingest/TempTableWorker.cs
@@ -66,7 +66,7 @@ namespace Klipboard.Workers
             var tempTableName = KustoDatabaseHelper.CreateTempTableName();
             var firstRowIsHeader = FirstRowIsHeader.Equals(chosenOption);
             using var databaseHelper = new KustoDatabaseHelper(target.ConnectionString, target.DatabaseName);
-            var m_ingestionRunner = new KustoIngestRunner(databaseHelper.GetDirectIngestClient(), degreeOfParallelism: 2);
+            var m_ingestionRunner = new KustoIngestRunner(databaseHelper.TryDirectIngestStorageToTable, degreeOfParallelism: 2);
 
             m_ingestionRunner.TraceEvent += (level, message) => 
             {
@@ -95,8 +95,7 @@ namespace Klipboard.Workers
                 {
                     using var file = File.OpenRead(path);
 
-                    var success = await HandleSingleTextStreamAsync(databaseHelper, tempTableName, file, formatResult, upstreamFileName, chosenOption, progressNotification, path
-                        );
+                    var success = await HandleSingleTextStreamAsync(databaseHelper, tempTableName, file, formatResult, upstreamFileName, chosenOption, progressNotification, path);
                     if (!success)
                     {
                         // A notification was sent from the failed function

--- a/Src/App/Workers/Misc/QuickActionsWorker.cs
+++ b/Src/App/Workers/Misc/QuickActionsWorker.cs
@@ -34,7 +34,7 @@ namespace Klipboard.Workers
         public override string GetMenuText(ClipboardContent content)
         {
             var config = m_settings.GetConfig();
-            string clusterName = config.ChosenCluster.ConnectionString.ToLower().SplitTakeLast("//").SplitFirst(".").SplitFirst(":").ToUpper();
+            string clusterName = GetClusterName(config.ChosenCluster.ConnectionString);
 
             // TODO - the correct way to do this is to have some framework which qualifies KVCs by the result of .show version once on creation.
             if (clusterName.StartsWith("KVC") && clusterName.Length >= 20)
@@ -86,6 +86,16 @@ namespace Klipboard.Workers
 
                 await m_settings.UpdateConfig(targetConfig);
             }
+        }
+
+        private string GetClusterName(string connectionString)
+        {
+            if(Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+            {
+                return uri.Host.ToUpper();
+            }
+
+            return connectionString.SplitTakeLast("//").SplitFirst(".").SplitFirst(":").ToUpper();
         }
 
         #region

--- a/Src/App/Workers/Misc/QuickActionsWorker.cs
+++ b/Src/App/Workers/Misc/QuickActionsWorker.cs
@@ -34,7 +34,7 @@ namespace Klipboard.Workers
         public override string GetMenuText(ClipboardContent content)
         {
             var config = m_settings.GetConfig();
-            string clusterName = config.ChosenCluster.ConnectionString.ToLower().SplitTakeLast("//").SplitFirst(".").ToUpper();
+            string clusterName = config.ChosenCluster.ConnectionString.ToLower().SplitTakeLast("//").SplitFirst(".").SplitFirst(":").ToUpper();
 
             // TODO - the correct way to do this is to have some framework which qualifies KVCs by the result of .show version once on creation.
             if (clusterName.StartsWith("KVC") && clusterName.Length >= 20)

--- a/Src/App/Workers/Query/ExternalDataQueryWorker.cs
+++ b/Src/App/Workers/Query/ExternalDataQueryWorker.cs
@@ -48,7 +48,7 @@ namespace Klipboard.Workers
                 m_notificationHelper.ShowBasicNotification(NotificationTitle, "External data query only supports a single file.");
             }
 
-            var file = files[0];
+            var file = FileHelper.NormalizeFilePathString(files[0]);
             var fileInfo = new FileInfo(file);
 
             if ((fileInfo.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
@@ -143,7 +143,7 @@ namespace Klipboard.Workers
             // Step #3 
             progressNotification.UpdateProgress("Running Query", 3 / 4.0, "step 4/4");
 
-            var blobPath = uploadRes.BlobUri.SplitFirst("?", out var blboSas).Replace(@"\", "/");
+            var blobPath = uploadRes.BlobUri.SplitFirst("?", out var blboSas);
             var queryBuilder = new StringBuilder();
 
             queryBuilder.AppendLine("// Query Created With Klipboard (https://github.com/yogilad/Klipboard/wiki)");

--- a/Src/App/Workers/Query/ExternalDataQueryWorker.cs
+++ b/Src/App/Workers/Query/ExternalDataQueryWorker.cs
@@ -143,7 +143,7 @@ namespace Klipboard.Workers
             // Step #3 
             progressNotification.UpdateProgress("Running Query", 3 / 4.0, "step 4/4");
 
-            var blobPath = uploadRes.BlobUri.SplitFirst("?", out var blboSas);
+            var blobPath = uploadRes.BlobUri.SplitFirst("?", out var blboSas).Replace(@"\", "/");
             var queryBuilder = new StringBuilder();
 
             queryBuilder.AppendLine("// Query Created With Klipboard (https://github.com/yogilad/Klipboard/wiki)");
@@ -153,8 +153,13 @@ namespace Klipboard.Workers
             queryBuilder.AppendLine("[");
             queryBuilder.Append(" '");
             queryBuilder.Append(blobPath);
-            queryBuilder.Append("' h'?");
-            queryBuilder.Append(blboSas);
+            
+            if (!string.IsNullOrWhiteSpace(blboSas))
+            {
+                queryBuilder.Append("' h'?");
+                queryBuilder.Append(blboSas);
+            }
+            
             queryBuilder.AppendLine("'");
             queryBuilder.AppendLine("]");
             queryBuilder.Append("with(");

--- a/Src/App/Workers/Query/ExternalDataQueryWorker.cs
+++ b/Src/App/Workers/Query/ExternalDataQueryWorker.cs
@@ -63,15 +63,19 @@ namespace Klipboard.Workers
             }
 
             var progressNotification = m_notificationHelper.ShowProgressNotification(NotificationTitle, $"Clipboard File", "Preparing Data", "Step 1/4");
-            var dt = DateTime.Now;
             var upsteramFileName = FileHelper.CreateUploadFileName(fileInfo.Name);
             var formatDefintion = FileHelper.GetFormatFromFileName(fileInfo.Name);
             using var dataStream = File.OpenRead(file);
 
-            await HandleStreamAsync(dataStream, formatDefintion, upsteramFileName, chosenOption, progressNotification);
+            await HandleStreamAsync(dataStream, formatDefintion, upsteramFileName, chosenOption, progressNotification, file);
         }
 
-        private async Task HandleStreamAsync(Stream dataStream, FileFormatDefiniton formatDefintion, string upstreamFileName, string? chosenOption, IProgressNotificationUpdater progressNotification)
+        private async Task HandleStreamAsync(Stream dataStream, 
+            FileFormatDefiniton formatDefintion, 
+            string upstreamFileName, 
+            string? chosenOption, 
+            IProgressNotificationUpdater progressNotification,
+            string? filePath = null)
         {
             using var databaseHelper = new KustoDatabaseHelper(m_settings.GetConfig().ChosenCluster);
             var firstRowIsHeader = FirstRowIsHeader.Equals(chosenOption);
@@ -79,7 +83,7 @@ namespace Klipboard.Workers
             // Step #1
             progressNotification.UpdateProgress("Uploading data", 1 / 4.0, "step 2/4");
 
-            var uploadRes = await databaseHelper.TryUploadFileToEngineStagingAreaAsync(dataStream, upstreamFileName, formatDefintion);
+            var uploadRes = await databaseHelper.TryUploadFileToEngineStagingAreaAsync(dataStream, upstreamFileName, formatDefintion, filePath);
 
             if (!uploadRes.Success)
             {


### PR DESCRIPTION
* Add support for working with a local instance of Kusto (Kusto Personal or a debug version of Kusto).
To do so, create a connection with the following format `http[s]://localhost[:port]`.
If you use http, Klipboard will connect to port 80 without authentication. 
You can override the default port.
**Please mind**, KWE does not properly open query links to localhost. 
For the moment, using Kusto Explorer Desktop is recommended. 

* Invoke Kusto Explorer Desktop without going through Edge
